### PR TITLE
Remove ctx flag because it was adding malformed headers to http respone

### DIFF
--- a/cmd/pops/pops.go
+++ b/cmd/pops/pops.go
@@ -432,7 +432,6 @@ func (m *Server) setupDataSink() (err error) {
 func (m *Server) setupHTTPServer() error {
 	m.logger.Log("Setting up http server")
 	sbPort := m.configs.mainConfig.ingestPort.Get()
-	//m.flagInRemote.CtxFlagger = &m.ctxLog
 	m.standardHeaders.Headers = map[string]string{}
 	listenAddr := fmt.Sprintf(":%d", sbPort)
 


### PR DESCRIPTION
remove ctxflag because it was adding malformed headers to http response