### PR TITLE
Upgrade go, rewrite makefile, and update port blocking tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,22 +2,24 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.11.0
+
     environment:
-      - NUM_DRAINING_THREADS: "2"
-      - CHANNEL_SIZE:          "10"
-      - MAX_DRAIN_SIZE:       "50"
+      - GOOS: "linux"
+
     working_directory: /go/src/github.com/signalfx/pops
 
     steps:
       - checkout
       - run: 
-          name: Setup Build Dependencies
-          command: make setup-build-tools
-      - run:
-          name: Build Binary
-          command: make binary
+          name: Setup Build Tools
+          command: make install-build-tools
       - run:
           name: Go Build
           command: make gobuild
+      - run:
+          name: Build
+          command: make build
+      - store_artifacts:
+          path: /go/src/github.com/signalfx/pops/output/linux/pops
 

--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,51 @@
-GO_VERSION=1.9
+GO_VERSION = 1.11.0
 
-default: binary
+.PHONY: deafult
+default: build
 
-with-container: # run a go distributed docker container and build for the target os inside the container
-	docker run --rm -t -e GOOS=linux -v $(CURDIR):/usr/local/go/src/github.com/signalfx/pops -w /usr/local/go/src/github.com/signalfx/pops golang:$(GO_VERSION) make in-container
-
-in-container:
-	make setup-build-tools
-	make gobuild
-	make race
-	make binary
-
-setup-build-tools:
+.PHONY: install-build-tools
+install-build-tools:
+	# install tools used for building
 	go get -u github.com/signalfx/gobuild
 	gobuild install
 	gometalinter --install
 
+.PHONY: clean
+clean:
+	# remove previous output
+	rm -rf $(CURDIR)/output
+
+.PHONY: gobuild
 gobuild:
-	gobuild --verbose check
+	# run gobuild to do everything except build
+	# we build in the build target with custom options
+	gobuild list
+	gobuild lint
+	gobuild dupl
+	gobuild test
 
-race:
-	go test -race -v ./...
-
-binary: # create an output directory and build the binaries for the desired version
+.PHONY: build
+build: clean
+	# build to a target directory with cgo disabled
 	mkdir -p $(CURDIR)/output/$(GOOS)
-	CGO_ENABLED=0 go build -v -o $(CURDIR)/output/$(GOOS)/pops $(CURDIR)/cmd/pops/pops.go
+	CGO_ENABLED=0 GOOS=$(GOOS) go build -v -o $(CURDIR)/output/$(GOOS)/pops $(CURDIR)/cmd/pops/pops.go
+	ls -la $(CURDIR)/output/$(GOOS)/
 
+.PHONY: with-container
+with-container:
+	# run a go distributed docker container and build for the target os inside the container
+	docker run --rm -t \
+		-e GOOS=linux \
+		-v $(CURDIR):/usr/local/go/src/github.com/signalfx/pops \
+		-w /usr/local/go/src/github.com/signalfx/pops \
+		golang:$(GO_VERSION) /bin/bash -c "set -e; make install-build-tools; make gobuild; make build"
+
+.PHONY: buildInfo
 buildInfo:
-	sh buildInfo.sh
+	# generate build info to be stored in the pops container
+	sh $(CURDIR)/buildInfo.sh
 
-container: buildInfo with-container # build container for pops service
-	docker build --no-cache -f $(CURDIR)/Dockerfile -t quay.io/signalfx/pops .
+.PHONY: container
+container: buildInfo with-container
+	# build container for pops service
+	docker build --no-cache -f $(CURDIR)/Dockerfile -t quay.io/signalfx/pops:$(shell git describe --tags) .

--- a/gobuild.toml
+++ b/gobuild.toml
@@ -1,6 +1,6 @@
 [vars]
   ignoreDirs = [".git", "_example", "vendor", "scripts", ".idea", "output"]
-  testFlags = ["-covermode", "atomic", "-timeout", "120s", "-cpu", "4", "-parallel", "8"]
+  testFlags = ["-covermode", "atomic", "-race", "-timeout", "120s", "-cpu", "4", "-parallel", "8"]
   duplLimit = "300"
   testCoverage = 100.0
 


### PR DESCRIPTION
* upgrade to golang 1.11.0
* tag container with git describe
* utilize gobuild for testing and race detection
* update circlei yaml to use new targets
* use random ports instead of hard coded ports in some tests 