### PR TITLE
When creating a POPS instance use a transport with a higher maxIdleConnsPerHost

### DIFF
--- a/cmd/pops.go
+++ b/cmd/pops.go
@@ -457,7 +457,6 @@ func makeHTTPClientFunc(numChannels, numDrainingThreads int64) func() *http.Clie
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
-		ForceAttemptHTTP2:     true,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/cmd/pops.go
+++ b/cmd/pops.go
@@ -451,7 +451,7 @@ func (m *Server) setupHealthCheck(r *mux.Router) {
 
 func (m *Server) makeHTTPClientFunc() func() *http.Client {
 	// Create a new transport with the defaults and update idle connection settings
-	transport := http.DefaultTransport.(*http.Transport)
+	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConns = int(m.configs.dataSinkConfig.MaxIdleConns.Get())
 	transport.MaxIdleConnsPerHost = int(m.configs.dataSinkConfig.MaxIdleConnsPerHost.Get())
 	return func() *http.Client {

--- a/cmd/pops.go
+++ b/cmd/pops.go
@@ -448,7 +448,7 @@ func (m *Server) setupHealthCheck(r *mux.Router) {
 func makeHTTPClientFunc(numChannels, numDrainingThreads int64) func() *http.Client {
 	maxConnections := int(numChannels * numDrainingThreads)
 	// Create a new transport with the defaults and update idle connection settings
-	// Once POPS is ugpraded to use go 1.13 we can use DefaultTransport.Clone and just overrirde
+	// Once POPS is upgraded to use go 1.13 we can use DefaultTransport.Clone and just overrirde
 	// maxIdleConns and MaxIdleConnsPerHost
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,


### PR DESCRIPTION
For the DefaultTransport, maxIdleConnsPerHost is set to 2. This causes POPS to reap a lot of idle connections it could be reusing instead causing a lot of overhead in the server and outbound proxy. By raising maxIdleConnsPerHost to numDrainingThreads * numChannels, POPS will be more likely to reuse connections when sending data to signalfx instead of building new ones.